### PR TITLE
Set active support to v5

### DIFF
--- a/lib/openlibrary/version.rb
+++ b/lib/openlibrary/version.rb
@@ -1,3 +1,3 @@
 module Openlibrary
-  VERSION = "2.1.3"
+  VERSION = "3.0.0"
 end

--- a/openlibrary.gemspec
+++ b/openlibrary.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'json', '>= 1.7.7'
   s.add_runtime_dependency 'rest-client', '~> 1.6'
   s.add_runtime_dependency 'hashie', '~> 2.0.2'
-  s.add_runtime_dependency 'activesupport', '~> 4'
+  s.add_runtime_dependency 'activesupport', '~> 5'
 end


### PR DESCRIPTION
Bump gem version to 3.0.0

Activesupport is set to all 5.x.x versions

Ruby version wasn't actually udpated before,
this commit actually updates it to 2.2.2