### PR TITLE
update webmock for ruby 2.4

### DIFF
--- a/openlibrary.gemspec
+++ b/openlibrary.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency 'rspec', '~> 3.6'
-  s.add_development_dependency 'webmock', '~> 1.11'
+  s.add_development_dependency 'webmock', '~> 3'
 
   s.add_runtime_dependency 'json', '>= 1.7.7'
   s.add_runtime_dependency 'rest-client', '~> 1.6'


### PR DESCRIPTION
`StubSocket` no longer has a `#close` method in Ruby 2.4. [Fixed in later versions](https://github.com/bblimke/webmock/issues/683).